### PR TITLE
Export Point and Matrix TypeScript types from package root

### DIFF
--- a/transformation-matrix.d.ts
+++ b/transformation-matrix.d.ts
@@ -1,15 +1,21 @@
-declare type Matrix = {
-  a: number;
-  b: number;
-  c: number;
-  d: number;
-  e: number;
-  f: number;
-};
+declare module 'transformation-matrix' {
+  type Matrix = {
+    a: number;
+    b: number;
+    c: number;
+    d: number;
+    e: number;
+    f: number;
+  };
 
-declare type Point = { x: number; y: number };
+  type Point = { x: number; y: number };
+
+  export { Point, Matrix };
+}
 
 declare module 'transformation-matrix/applyToPoint' {
+  import { Point, Matrix } from 'transformation-matrix';
+
   /** Calculate a point transformed with an affine matrix */
   export function applyToPoint(matrix: Matrix, point: Point): Point;
   /** Calculate an array of points transformed with an affine matrix */
@@ -17,11 +23,15 @@ declare module 'transformation-matrix/applyToPoint' {
 }
 
 declare module 'transformation-matrix/fromString' {
+  import { Matrix } from 'transformation-matrix';
+
   /** Parse a string matrix formatted as `matrix(a,b,c,d,e,f)` */
   export function fromString(str: string): Matrix;
 }
 
 declare module 'transformation-matrix/fromObject' {
+  import { Point, Matrix } from 'transformation-matrix';
+
   /**
    * Extract an affine matrix from an object that contains a,b,c,d,e,f keys.
    * Each value could be a float or a string that contains a float
@@ -37,21 +47,29 @@ declare module 'transformation-matrix/fromObject' {
 }
 
 declare module 'transformation-matrix/identity' {
+  import { Matrix } from 'transformation-matrix';
+
   /** Identity matrix */
   export function identity(): Matrix;
 }
 
 declare module 'transformation-matrix/inverse' {
+  import { Matrix } from 'transformation-matrix';
+
   /** Calculate a matrix that is the inverse of the provided matrix */
   export function inverse(matrix: Matrix): Matrix;
 }
 
 declare module 'transformation-matrix/isAffineMatrix' {
+  import { Matrix } from 'transformation-matrix';
+
   /** Check if the object contain an affine matrix */
   export function isAffineMatrix(obj: object): boolean;
 }
 
 declare module 'transformation-matrix/rotate' {
+  import { Matrix } from 'transformation-matrix';
+
   /**
    * Calculate a rotation matrix
    * @param angle Angle in radians
@@ -67,6 +85,8 @@ declare module 'transformation-matrix/rotate' {
 }
 
 declare module 'transformation-matrix/scale' {
+  import { Matrix } from 'transformation-matrix';
+
   /**
    * Calculate a scaling matrix
    * @param sx Scaling on axis x
@@ -76,16 +96,22 @@ declare module 'transformation-matrix/scale' {
 }
 
 declare module 'transformation-matrix/shear' {
+  import { Matrix } from 'transformation-matrix';
+
   /** Calculate a shear matrix */
   export function shear(shx: number, shy: number): Matrix;
 }
 
 declare module 'transformation-matrix/skew' {
+  import { Matrix } from 'transformation-matrix';
+
   /** Calculate a skew matrix */
   export function skew(ax: number, ay: number): Matrix;
 }
 
 declare module 'transformation-matrix/toString' {
+  import { Matrix } from 'transformation-matrix';
+
   /**
    * Serialize the matrix to a string that can be used with CSS or SVG
    * @returns {string} String that contains a matrix formatted as `matrix(a,b,c,d,e,f)`
@@ -104,11 +130,15 @@ declare module 'transformation-matrix/toString' {
 }
 
 declare module 'transformation-matrix/transform' {
+  import { Matrix } from 'transformation-matrix';
+
   /** Merge multiple matrices into one */
   export function transform(...matrices: Matrix[]): Matrix;
 }
 
 declare module 'transformation-matrix/translate' {
+  import { Matrix } from 'transformation-matrix';
+
   /**
    * Calculate a translate matrix
    * @param tx Translation on axis x


### PR DESCRIPTION
Fixes #16 

The `Matrix` and `Point` types can now be imported from the package root like this:

```
import { Point, Matrix } from 'transformation-matrix';
```