### PR TITLE
fixes declaration file

### DIFF
--- a/transformation-matrix.d.ts
+++ b/transformation-matrix.d.ts
@@ -1,5 +1,3 @@
-import {Matrix} from "transformation-matrix";
-
 declare module 'transformation-matrix' {
   type Matrix = {
     a: number;


### PR DESCRIPTION
I using this package with TypeScript.
In v1.14.1, I can import functions (e.g. rotateDEG).
But in v1.15.2, I can't.

Problem was caused by declaration file.
First line causes error.
I think first line was written by editor automatically.

I fixed declaration file.
