### PR TITLE
Fix #55 fromDefinition parametric typings

### DIFF
--- a/transformation-matrix.d.ts
+++ b/transformation-matrix.d.ts
@@ -218,10 +218,10 @@ declare module 'transformation-matrix/fromDefinition' {
    *  { a: 1, c: 10, e: 0, b: 20, d: 1, f: 0 }
    * ]
    **/
-   export function fromDefinition(defintion: MatrixDescriptor): Matrix;
-   export function fromDefinition(
+  export function fromDefinition(defintion: MatrixDescriptor): Matrix;
+  export function fromDefinition(
     arrayOfDefintion: MatrixDescriptor[]
-   ): Matrix[];
+  ): Matrix[];
 }
 
 declare module 'transformation-matrix/fromTransformAttribute' {

--- a/transformation-matrix.d.ts
+++ b/transformation-matrix.d.ts
@@ -218,7 +218,10 @@ declare module 'transformation-matrix/fromDefinition' {
    *  { a: 1, c: 10, e: 0, b: 20, d: 1, f: 0 }
    * ]
    **/
-  export function fromDefinition(...definitionOrArrayOfDefinition: MatrixDescriptor | MatrixDescriptor[]): Matrix[];
+   export function fromDefinition(defintion: MatrixDescriptor): Matrix;
+   export function fromDefinition(
+    arrayOfDefintion: MatrixDescriptor[]
+   ): Matrix[];
 }
 
 declare module 'transformation-matrix/fromTransformAttribute' {


### PR DESCRIPTION
This fixes the issue introduced in my previous PR. As raised by @0v3rst33r and @yevhen-kutishchev.

One important thing to note is that when providing descriptors to the function the descriptor value will need to be explicitly typed as a MatrixDescriptor, otherwise TypeScript will automatically widen the value's type in such a way that it becomes incompatible with the function param.

e.g.
```typescript
const d2: MatrixDescriptor = { type: "scale", sx: 1, sy: 2 };
fromDefinition(d); // no type error

const d3 = { type: "scale", sx: 1, sy: 2 } as const;
fromDefinition(d); // no type error

const d1 = { type: "scale", sx: 1, sy: 2 };
fromDefinition(d); // complains that param is invalid type
```

Personally I feel like although this is a suboptimal experience it is still better than the alternative, but I will completely understand if others feel differently.