### PR TITLE
Improve return type inference of `applyToPoint`

### DIFF
--- a/transformation-matrix.d.ts
+++ b/transformation-matrix.d.ts
@@ -26,9 +26,9 @@ declare module 'transformation-matrix/applyToPoint' {
   import { Point, Matrix } from 'transformation-matrix';
 
   /** Calculate a point transformed with an affine matrix */
-  export function applyToPoint(matrix: Matrix, point: Point): Point;
+  export function applyToPoint<P extends Point>(matrix: Matrix, point: P): P;
   /** Calculate an array of points transformed with an affine matrix */
-  export function applyToPoints(matrix: Matrix, points: Point[]): Point[];
+  export function applyToPoints<P extends Point>(matrix: Matrix, points: P[]): P[];
 }
 
 declare module 'transformation-matrix/fromString' {


### PR DESCRIPTION
`applyToPoint` and `applyToPoints` accept points of the form `[1, 2]` or `{ x: 1, y: 2 }`. The shape of the points they return matches the shape that was passed in. However, the previous type definitions did not capture this relationship (that is, "the shape returned matches the shape that was passed in"). This change updates the type definitions to fix this deficiency.

I've written more about this at https://github.com/bgschiller/whybother-ts/blob/master/okay-im-convinced/generic-functions/README.md

If you're interested, I'd be happy to prepare a PR that adds a test to verify this change and prevent regressions using [tsd](https://github.com/SamVerschueren/tsd)