### PR TITLE
Fix circular dependency import at fromMovingPoints file

### DIFF
--- a/src/fromMovingPoints.js
+++ b/src/fromMovingPoints.js
@@ -1,8 +1,8 @@
 import { translate } from './translate'
 import { applyToPoint } from './applyToPoint'
-export { rotate } from './rotate'
-export { scale } from './scale'
-export { compose } from './transform'
+import { rotate } from './rotate'
+import { scale } from './scale'
+import { compose } from './transform'
 
 // https://manivannan-ai.medium.com/find-the-angle-between-three-points-from-2d-using-python-348c513e2cd
 

--- a/src/fromMovingPoints.js
+++ b/src/fromMovingPoints.js
@@ -2,7 +2,7 @@ import { translate } from './translate'
 import { applyToPoint } from './applyToPoint'
 export { rotate } from './rotate'
 export { scale } from './scale'
-export { compose } from './compose'
+export { compose } from './transform'
 
 // https://manivannan-ai.medium.com/find-the-angle-between-three-points-from-2d-using-python-348c513e2cd
 

--- a/src/fromMovingPoints.js
+++ b/src/fromMovingPoints.js
@@ -1,6 +1,8 @@
 import { translate } from './translate'
 import { applyToPoint } from './applyToPoint'
-import { scale, rotate, compose } from './index'
+export { rotate } from './rotate'
+export { scale } from './scale'
+export { compose } from './compose'
 
 // https://manivannan-ai.medium.com/find-the-angle-between-three-points-from-2d-using-python-348c513e2cd
 


### PR DESCRIPTION
Rollup reporting circular dependency import at `fromMovingPoints` file

```
Circular dependency: ../../node_modules/transformation-matrix/src/index.js -> ../../node_modules/transformation-matrix/src/fromMovingPoints.js -> ../../node_modules/transformation-matrix/src/index.js
```